### PR TITLE
Remove runfile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,6 @@ contents.
   Write to _file_ the text supplied as the _content_ parameter.
   This can be either a string, or an array of strings.
 
-- `runfile(file)`
-
-  Run _file_ if it's a lua script.
-
 ## Editor
 
 If a project is open, the files inside can be edited or new ones

--- a/src/controller/consoleController.lua
+++ b/src/controller/consoleController.lua
@@ -311,18 +311,6 @@ function ConsoleController.prepare_env(cc)
   end
 
   --- @param name string
-  --- @return any
-  prepared.runfile          = function(name)
-    local code = check_open_pr(cc._readfile, cc, name)
-    local chunk, err = load(code, '', 't')
-    if chunk then
-      chunk()
-    else
-      print(err)
-    end
-  end
-
-  --- @param name string
   prepared.edit             = function(name)
     return check_open_pr(cc.edit, cc, name)
   end


### PR DESCRIPTION
Made redundant by properly working `require`