### PR TITLE
fix(views/userInput): crash on space typed [#131]

### DIFF
--- a/src/view/input/userInputView.lua
+++ b/src/view/input/userInputView.lua
@@ -189,8 +189,8 @@ function UserInputView:render_input(input, status, time)
             color = Color[ci] or colors.fg
           end
         end
-        if perr and ln > el or
-            (ln == el and (c > ec or ec == 1)) then
+        if el and ln > el or
+            (ln == el and (ec and c > ec or ec == 1)) then
           color = cf_colors.input.error
         end
         local selected = (function()


### PR DESCRIPTION
Stricter check for actual presence of error lines in 'parsed error' container

Closes: #131