### PR TITLE
fix(editor): restore Lua line length validation

### DIFF
--- a/src/model/interpreter/eval/evaluator.lua
+++ b/src/model/interpreter/eval/evaluator.lua
@@ -185,7 +185,7 @@ LuaEditorEval = (function()
   local line_length = max_length(64)
 
   local ft = {
-    validators = { line_length },
+    line_validators = { line_length },
     astValidators = { test },
   }
   return LuaEval(nil, ft)

--- a/tests/interpreter/eval_spec.lua
+++ b/tests/interpreter/eval_spec.lua
@@ -1,4 +1,5 @@
 local LANG = require("util.eval")
+require("model.interpreter.eval.evaluator")
 
 --- @param expr string
 --- @param result any?
@@ -119,4 +120,14 @@ describe('extracts error message info', function()
       assert.same(eln, ln)
     end)
   end
+end)
+
+describe('Lua editor eval', function()
+  it('rejects overlong lines', function()
+    local line = string.rep('a', 65) .. ' = 1'
+    local ok, errors = LuaEditorEval:apply({ line })
+
+    assert.is_false(ok)
+    assert.truthy(string.find(tostring(errors[1]), 'line too long!', 1, true))
+  end)
 end)


### PR DESCRIPTION
## Summary
- register the Lua editor line-length guard under line_validators after the evaluator filter rename
- add a focused evaluator test proving overlong editor input is rejected

## Context
LuaEditorEval still used validators even though Evaluator.new reads line_validators. The line-length validator was therefore not registered.

## Verification
- lua5.1 /usr/lib/luarocks/rocks-5.1/busted/2.3.0-1/bin/busted tests/interpreter/eval_spec.lua
- lua5.1 /usr/lib/luarocks/rocks-5.1/busted/2.3.0-1/bin/busted tests