### PR TITLE
fix(editor): accept exact Lua line length limit

### DIFF
--- a/src/model/interpreter/eval/evaluator.lua
+++ b/src/model/interpreter/eval/evaluator.lua
@@ -176,7 +176,7 @@ LuaEditorEval = (function()
   --- text validations
   local max_length = function(n)
     return function(s)
-      if string.len(s) < n then
+      if string.len(s) <= n then
         return true
       end
       return false, 'line too long!'


### PR DESCRIPTION
## Summary
- treat the documented 64-character Lua editor line limit as inclusive
- change the line-length helper from < n to <= n

## Context
This is a small companion to #18. #18 wires LuaEditorEval's line-length validator back into Evaluator.new; this PR fixes the boundary condition that becomes visible once that validator is active. The order is not dangerous: this change is inert until the validator is registered, and correct once #18 lands.

## Testing
- lua5.1 /usr/lib/luarocks/rocks-5.1/busted/2.3.0-1/bin/busted tests/interpreter/eval_spec.lua
- lua5.1 /usr/lib/luarocks/rocks-5.1/busted/2.3.0-1/bin/busted tests

## Notes
- No new dedicated regression spec is added here; #18 already covers the validator path, and this PR is the one-line boundary correction.