### PR TITLE
fix(editor): comments+gaps handling [Fixes #114]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "src/lib/metalua"]
 	path = src/lib/metalua
 	url = https://github.com/compy-toys/metalua.git
+	branch = dev
 
 [submodule "src/util/string"]
 	path = src/util/string

--- a/src/controller/editorController.lua
+++ b/src/controller/editorController.lua
@@ -345,7 +345,14 @@ function EditorController:_handle_submit(go)
         if #chunks < #raw_chunks then
           local rc = raw_chunks
           if rc[1]:is_empty() then
-            table.insert(chunks, 1, Empty(0))
+            --- Leading empty in raw may be editor padding before the
+            --- first real block; do not restore it when pprint already
+            --- starts with content.
+            local has_leading_content = chunks[1]
+                and chunks[1]:is_empty()
+            if not has_leading_content then
+              table.insert(chunks, 1, Empty(rc[1].pos.start))
+            end
           end
           if rc[#rc]:is_empty() then
             local li = chunks[#chunks].pos.fin
@@ -596,6 +603,7 @@ function EditorController:_normal_mode_keys(k)
       input:jump_home()
     end
   end
+
 
 
   --- handlers

--- a/src/model/lang/lua/parser.lua
+++ b/src/model/lang/lua/parser.lua
@@ -311,11 +311,13 @@ return function(lib)
       local wrap = w
       local ret = Dequeue.typed('block')
       local ok, r = parse(text)
+
       local has_lines = false
       if ok then
         local idx = 1  -- block number
         local last = 0 -- last line number
         local comment_ids = {}
+        local comment_lines = {}
         --- Create chunk from comment text and pos
         --- @param ctext str
         --- @param c Comment
@@ -326,6 +328,7 @@ return function(lib)
             idx)
           comment_ids[c.idf] = true
           comment_ids[c.idl] = true
+          comment_lines[c.first.l] = true
         end
         --- @param comments Comment[]
         --- @param pos CommentPos
@@ -334,7 +337,8 @@ return function(lib)
             -- Log.warn('c', c.position)
             -- Log.warn(Debug.terse_t(c, nil, nil, true))
             if c.position == pos
-                and not (comment_ids[c.idl] or comment_ids[c.idf])
+                and not (comment_ids[c.idl] or comment_ids[c.idf]
+                    or comment_lines[c.first.l])
             then
               local cfl, cll = c.first.l, c.last.l
               -- account for empty lines
@@ -343,6 +347,7 @@ return function(lib)
                 idx = idx + 1
                 comment_ids[c.idf] = true
                 comment_ids[c.idl] = true
+                comment_lines[cfl] = true
               end
               if cfl == cll then
                 local ctext = '--' .. c.text
@@ -409,7 +414,7 @@ return function(lib)
           get_comments(comments, 'last')
         end
 
-        if single or not has_lines then
+        if not has_lines then
           --- @diagnostic disable-next-line: param-type-mismatch
           local single_comment = ast_extract_comments(r, {}, wrap)
           get_comments(single_comment, 'first')

--- a/tests/editor/editor_spec.lua
+++ b/tests/editor/editor_spec.lua
@@ -599,6 +599,68 @@ describe('Editor #editor', function()
                       "saved content not changed")
           session:assert_cursor_at(session:input_line_of(f_over_new))
         end)
+
+        -- see issue #114
+        it ("extra emptyline+comment before single LOC", function()
+          local emptyline = ''
+          local comment = '-- comment'
+          local single_loc = 'print("original line of code")'
+
+
+          local orig = src(single_loc, emptyline)
+          local edited = src(emptyline, comment, single_loc)
+
+          local input, buffer = session:open(orig)
+          session:select_and_open_block(1, single_loc)
+
+          session:submit( edited )
+
+          local expected  = src(emptyline,
+                                comment,
+                                emptyline,
+                                single_loc,
+                                emptyline)
+
+          assert.same( expected, savefile() )
+        end)
+
+        it ("extra emptyline+comment before block", function()
+          local emptyline = ''
+          local comment = '-- comment'
+          local block = mock_func_snippet("orig_block")
+
+
+          local orig = src(block, emptyline)
+          local edited = src(emptyline, comment, block)
+
+          local input, buffer = session:open(orig)
+          session:select_and_open_block(1, single_loc)
+
+          session:submit( edited )
+
+          local expected  = src(emptyline,
+                                comment,
+                                emptyline,
+                                block,
+                                emptyline)
+
+          assert.same( expected, savefile() )
+        end)
+
+        it ("extra emptyline before comment", function()
+          local emptyline = ''
+          local comment = '-- comment'
+
+          local orig = src(comment)
+          local edited = src(emptyline, comment)
+
+          local input, buffer = session:open(orig)
+          session:select_and_open_block(1, comment)
+
+          session:submit( edited )
+          assert.same( edited.."\n", savefile() )
+        end)
+
       end)
 
       describe("insertion of", function()


### PR DESCRIPTION
* metalua dependence updated (recent version with related fixes)
* tests added for targeted use-cases
* editor avoids comments duplication
* editor preserves emptyline preceding the comment before block


This PR supersedes draft #17 