### PR TITLE
build: package love archive as zip

### DIFF
--- a/justfile
+++ b/justfile
@@ -134,7 +134,8 @@ one-harmony:
 VERSION := `git describe --tags --long --always`
 
 package: version
-  @7z a {{DIST}}/game.love ./src/* > /dev/null
+  @rm -f {{DIST}}/game.love
+  @7z -tzip a {{DIST}}/game.love ./src/* > /dev/null
   @echo packaged:
   @ls -lh {{DIST}}/game.love
 


### PR DESCRIPTION
Fixes the Linux .love package format so the fused Compy-linux binary launches the IDE instead of the generic LÖVE window.

Validation:
- dev/tools/build linux
- file repos/compy-ide/dist/game.love
- unzip -t repos/compy-ide/dist/game.love main.lua conf.lua
