### PR TITLE
(A4): fix(console): coerce non-string error in user_error_handler

### DIFF
--- a/src/controller/controller.lua
+++ b/src/controller/controller.lua
@@ -41,8 +41,9 @@ local _supported = {
 }
 
 --- @param CC ConsoleController
---- @param msg string
+--- @param msg any
 local function user_error_handler(CC, msg)
+  msg = tostring(msg)
   Log.debug('user error: ' .. msg)
   local err = LANG.get_call_error(msg) or ''
   local user_msg = messages.exec_error(err)


### PR DESCRIPTION
error({...}) / error(nil) crashed the handler before suspend_run, so the error screen never showed. Coerce msg with tostring; downstream err is then always a string.