### PR TITLE
fix(view): release snapshot image instead of leaking it

### DIFF
--- a/src/controller/controller.lua
+++ b/src/controller/controller.lua
@@ -401,6 +401,7 @@ Controller = {
       if love.state.app_state == 'snapshot' then
         gfx.captureScreenshot(function(img)
           local snap = gfx.newImage(img)
+          if View.snapshot then View.snapshot:release() end
           View.snapshot = snap
           CC:suspend()
         end)

--- a/src/view/view.lua
+++ b/src/view/view.lua
@@ -19,6 +19,7 @@ View = {
   end,
 
   clear_snapshot = function()
+    if View.snapshot then View.snapshot:release() end
     View.snapshot = nil
   end,
 


### PR DESCRIPTION
Each suspend created a new screenshot Image via gfx.newImage but never released the previous one; clear_snapshot only nil'd it. Release on overwrite and on clear so VRAM is freed instead of held until GC.