### PR TITLE
fix(terminal): gate per-frame repaint on dirty flag

### DIFF
--- a/src/model/canvasModel.lua
+++ b/src/model/canvasModel.lua
@@ -55,6 +55,7 @@ end
 function CanvasModel:write(text)
   if string.is_non_empty_string(text) then
     self.terminal:print(text)
+    self.terminal.dirty = true
   end
 end
 
@@ -70,9 +71,11 @@ end
 function CanvasModel:reset()
   self.terminal:clear()
   self.terminal:move_to(1, 1)
+  self.terminal.dirty = true
 end
 
 function CanvasModel:invalidate_terminal()
+  self.terminal.dirty = true
 end
 
 function CanvasModel:update(dt)

--- a/src/view/canvas/terminalView.lua
+++ b/src/view/canvas/terminalView.lua
@@ -9,7 +9,7 @@ local function terminal_draw(terminal, canvas, overlay)
   local char_width, char_height =
       terminal.char_width, terminal.char_height
 
-  -- if terminal.dirty or overlay then
+  if terminal.dirty or overlay then
   gfx.push('all')
 
   gfx.setCanvas(canvas)
@@ -61,7 +61,7 @@ local function terminal_draw(terminal, canvas, overlay)
   end
   terminal.dirty = false
   gfx.pop()
-  -- end
+  end
 
 
   if terminal.show_cursor then


### PR DESCRIPTION
terminalView redrew the whole grid every frame (dirty gate was commented out, invalidate_terminal was a no-op). Restore the terminal-level dirty gate, implement invalidate_terminal, and mark the terminal dirty on write/reset so scrolling still repaints. Verified on desktop LÖVE: output, errors, and scroll-on-fill work; device test pending for battery/frame-time.