### PR TITLE
fix(project): robust project file loading (A5, C6)

### DIFF
--- a/src/model/project/project.lua
+++ b/src/model/project/project.lua
@@ -382,7 +382,8 @@ function ProjectService:run(name, env)
     p_path, err = self.is_project(ProjectService.path, name)
   end
   if p_path then
-    local _, code = self.current:readfile(ProjectService.MAIN)
+    local ok, code = self.current:readfile(ProjectService.MAIN)
+    if not ok then return nil, code, p_path end
     local content, c_err = codeload(code, env)
     return content, c_err, p_path
   end

--- a/src/model/project/project.lua
+++ b/src/model/project/project.lua
@@ -384,6 +384,9 @@ function ProjectService:run(name, env)
   if p_path then
     local ok, code = self.current:readfile(ProjectService.MAIN)
     if not ok then return nil, code, p_path end
+    if type(code) ~= 'string' then
+      return nil, FS.messages.unreadable(ProjectService.MAIN), p_path
+    end
     local content, c_err = codeload(code, env)
     return content, c_err, p_path
   end

--- a/src/util/lua.lua
+++ b/src/util/lua.lua
@@ -14,6 +14,9 @@ end
 --- @return function? chunk
 --- @return string? err
 local codeload = function(code, env)
+  if type(code) ~= 'string' then
+    return nil, 'no code to load'
+  end
   local f, err = loadstring(code)
 
   if not f then return nil, err end

--- a/src/util/lua.lua
+++ b/src/util/lua.lua
@@ -15,7 +15,7 @@ end
 --- @return string? err
 local codeload = function(code, env)
   if type(code) ~= 'string' then
-    return nil, 'no code to load'
+    return nil, ('code must be a string (got %s)'):format(type(code))
   end
   local f, err = loadstring(code)
 


### PR DESCRIPTION
A5: codeload crashed on non-string input (readfile can yield nil content on read race / missing read / SD eject); guard and return an error instead of loadstring(nil). C6: ProjectService:run discarded the readfile success flag, so a missing main.lua compiled the error message as code; check the flag and return the real message.