### PR TITLE
fix(redirect): guard terminal push so a fault can't cascade through print

### DIFF
--- a/src/model/io/redirect.lua
+++ b/src/model/io/redirect.lua
@@ -13,7 +13,9 @@ local function set_print(M)
       if i ~= l then out = out .. '\t' end
     end
     origPrint(out)
-    pcall(M.output.push, M.output, out)
+    -- origPrint above has already emitted the output
+    -- (and the error, if there was any)
+    local _ = pcall(M.output.push, M.output, out)
   end
   _G.print = magicPrint
 end

--- a/src/model/io/redirect.lua
+++ b/src/model/io/redirect.lua
@@ -13,7 +13,7 @@ local function set_print(M)
       if i ~= l then out = out .. '\t' end
     end
     origPrint(out)
-    M.output:push(out)
+    pcall(M.output.push, M.output, out)
   end
   _G.print = magicPrint
 end


### PR DESCRIPTION
magicPrint's M.output:push was unprotected; since IDE error paths call print, one terminal push fault would throw and cascade through every later print. Wrap push in pcall — origPrint already echoed the output above, so nothing is lost.