### PR TITLE
fix(editor): selection crashes on empty buffer (A6, A7)

### DIFF
--- a/src/model/editor/bufferModel.lua
+++ b/src/model/editor/bufferModel.lua
@@ -242,6 +242,9 @@ end
 
 --- @param sel integer
 function BufferModel:set_selection(sel)
+  local max = self:get_content_length() + 1
+  if not sel or sel < 1 then sel = 1 end
+  if sel > max then sel = max end
   self.selection = sel
 end
 
@@ -258,7 +261,8 @@ function BufferModel:_get_selected_block()
 
   local sel = self.selection
   if sel == self:get_content_length() + 1 then
-    local ln = self.content:last().pos.fin + 1
+    local last = self.content:last()
+    local ln = (last and last.pos.fin or 0) + 1
     return Empty(ln)
   end
   return self.content[sel]

--- a/src/model/editor/searchModel.lua
+++ b/src/model/editor/searchModel.lua
@@ -31,6 +31,7 @@ Search = class.create(function(cfg)
     input = UserInputModel(cfg, nil, false, 'search'),
     searchset = {},
     resultset = {},
+    selection = 1,
     visible = ScrollableContent(0, 1, l)
   }
 end)


### PR DESCRIPTION
A6: Search never initialized selection in its constructor, so opening search on an empty buffer and pressing up/down did arithmetic on nil. Initialize selection = 1. A7: BufferModel:set_selection took any value unchecked and restore_state feeds a saved selection unconditionally, so a stale selection on an emptied buffer indexed nil via content:last(). Clamp selection to the buffer range, and guard last() for empty content.