### PR TITLE
fix(console): correct terminal_test state guard

### DIFF
--- a/src/controller/consoleController.lua
+++ b/src/controller/consoleController.lua
@@ -958,7 +958,7 @@ function ConsoleController:keypressed(k)
   local function terminal_test()
     local out = self.model.output
     if love.state.app_state ~= 'ready'
-        or love.state.app_state ~= 'project_open'
+        and love.state.app_state ~= 'project_open'
     then
       return
     end

--- a/src/controller/consoleController.lua
+++ b/src/controller/consoleController.lua
@@ -957,9 +957,7 @@ function ConsoleController:keypressed(k)
 
   local function terminal_test()
     local out = self.model.output
-    if love.state.app_state ~= 'ready'
-        and love.state.app_state ~= 'project_open'
-    then
+    if love.state.app_state ~= 'ready' then
       return
     end
     if not love.state.testing then


### PR DESCRIPTION
The guard used ~= 'ready' or ~= 'project_open', which is always true, so terminal_test always returned early and never ran. Should be and: skip only when the state is neither ready nor project_open.