### PR TITLE
fix(color): keep green/blue order in with_alpha

### DIFF
--- a/src/util/color.lua
+++ b/src/util/color.lua
@@ -38,7 +38,7 @@ Color = {
   --- @param alpha number
   with_alpha = function(color, alpha)
     if type(color) == "table" then
-      local red, blue, green = color[1], color[2], color[3]
+      local red, green, blue = color[1], color[2], color[3]
       return { red, green, blue, alpha }
     end
   end,


### PR DESCRIPTION
with_alpha bound color[2]/color[3] to locals named blue/green and returned {red, green, blue, alpha}, so it transposed green and blue. Fix the local names so the channels are preserved. Note: this changes the rendered tint of alpha-dimmed UI (editor dimming, search results, terminal overlay), which has been using swapped channels until now.