### PR TITLE
fix(os): popen handle leak and exit-code parse crash (B4, A8)

### DIFF
--- a/src/util/os.lua
+++ b/src/util/os.lua
@@ -14,7 +14,8 @@ end
 
 --- @return boolean success
 local function test_popen()
-  local ok = pcall(io.popen, 'echo')
+  local ok, handle = pcall(io.popen, 'echo')
+  if ok and handle then handle:close() end
   return ok
 end
 
@@ -46,10 +47,11 @@ local function runcmd_with_exit(cmd)
   if handle then
     local result = handle:read("*a")
     handle:close()
-    local _, _, exit_code = result:find("(%d+)%s*$")
-    result = result:sub(1,
-      result:find("(%d+)%s*$") - 1):gsub("%s+$", ""
-    )
+    local s, _, exit_code = result:find("(%d+)%s*$")
+    if not s then
+      return false, result
+    end
+    result = result:sub(1, s - 1):gsub("%s+$", "")
     exit_code = tonumber(exit_code)
     if exit_code ~= 0 then
       return false, result


### PR DESCRIPTION
B4: test_popen ran io.popen('echo') via pcall but never closed the returned handle, leaking one per call. Capture and close it. A8: runcmd_with_exit did result:find("(%d+)%s*$") - 1, which throws when the output has no trailing digits (nil - 1). Capture the position once, return failure if absent, and drop the redundant second find.