### PR TITLE
fix(fs): drop truncating probe-open in desktop cp (B5)

### DIFF
--- a/src/util/filesystem.lua
+++ b/src/util/filesystem.lua
@@ -375,13 +375,8 @@ else
   --- @return string? error
   function FS.cp(source, target)
     local src = FS.exists(source)
-    local tgt = io.open(target, "w")
-
     if not src then
-      return false, FS.messages.cannot_open(src)
-    end
-    if not tgt then
-      return false, FS.messages.cannot_open(tgt)
+      return false, FS.messages.cannot_open(source)
     end
 
     local rok, cont_err = FS.read(source)


### PR DESCRIPTION
Desktop FS.cp opened the target with io.open(target, "w") only as a writability probe: it never wrote through that handle, never closed it (leak), and "w" truncated the target before the source was even read. Removed the probe — FS.write already opens and reports errors. Also pass the path, not the boolean, to cannot_open.