### PR TITLE
fix(dequeue): weak-key the tags table by object (B2)

### DIFF
--- a/src/util/dequeue.lua
+++ b/src/util/dequeue.lua
@@ -23,7 +23,7 @@ local class = require('util.class')
 --- @field move function
 Dequeue = class.create()
 
-local tags = {}
+local tags = setmetatable({}, { __mode = 'k' })
 
 --- Create a new double-ended queue
 --- @param values table?
@@ -53,8 +53,7 @@ function Dequeue.new(values, tag)
       self:push_back(v)
     end
   end
-  local addr = tostring(self)
-  tags[addr] = ttag
+  tags[self] = ttag
   return self
 end
 
@@ -79,7 +78,7 @@ end
 --- Return item type
 --- @return string?
 function Dequeue:type()
-  return tags[tostring(self)]
+  return tags[self]
 end
 
 function Dequeue:get_type()


### PR DESCRIPTION
The module-level tags table was keyed by tostring(self) and never pruned, so it grew for the whole process lifetime; worse, a reused address could mis-tag a new Dequeue. Make tags weak-keyed (__mode = 'k') and key by the object itself, so entries are collected with their Dequeue and addresses can't collide.