### PR TITLE
fix(project): propagate play-open error from opreate (E8)

### DIFF
--- a/src/model/project/project.lua
+++ b/src/model/project/project.lua
@@ -290,8 +290,8 @@ end
 --- @return string? err
 function ProjectService:opreate(name, play)
   if play then
-    local ok = self:open('play', true)
-    return ok, false
+    local ok, err = self:open('play', true)
+    return ok, false, err
   else
     local ook, _ = self:open(name, false)
     if ook then


### PR DESCRIPTION
The play branch of opreate captured only the first return of self:open('play', true), discarding the error, so a failed play-open surfaced as print(nil) at the caller. Return the error as the third value. (Note: the audit's "drops c_err" is imprecise — the create error already reaches the caller; the real dropped error is the play-open one.)