### PR TITLE
fix(lua): pass chunkname to codeload (E9)

### DIFF
--- a/src/model/project/project.lua
+++ b/src/model/project/project.lua
@@ -109,7 +109,7 @@ end
 function Project:load_file(filename)
   local rok, content = self:readfile(filename)
   if rok then
-    return codeload(content)
+    return codeload(content, nil, filename)
   end
 end
 
@@ -387,7 +387,7 @@ function ProjectService:run(name, env)
     if type(code) ~= 'string' then
       return nil, FS.messages.unreadable(ProjectService.MAIN), p_path
     end
-    local content, c_err = codeload(code, env)
+    local content, c_err = codeload(code, env, ProjectService.MAIN)
     return content, c_err, p_path
   end
   return nil, err

--- a/src/util/lua.lua
+++ b/src/util/lua.lua
@@ -11,13 +11,15 @@ end
 
 --- @param code string
 --- @param env table?
+--- @param name string?
 --- @return function? chunk
 --- @return string? err
-local codeload = function(code, env)
+local codeload = function(code, env, name)
   if type(code) ~= 'string' then
     return nil, ('code must be a string (got %s)'):format(type(code))
   end
-  local f, err = loadstring(code)
+  local chunk = name and ('@' .. name) or nil
+  local f, err = loadstring(code, chunk)
 
   if not f then return nil, err end
   if env then


### PR DESCRIPTION
codeload called loadstring with no chunkname, so user code errors cited [string "…"] instead of the file. Add an optional name param and load with '@'..name, and pass the filename from load_file and ProjectService:run. Console input (no file) is left unnamed. NOTE: this touches the same codeload function as #27 (A5/C6) — #27 should be merged first; this branch will be rebased on top to resolve the overlap.