### PR TITLE
fix(console): make use_canvas exception-safe (C2)

### DIFF
--- a/src/controller/consoleController.lua
+++ b/src/controller/consoleController.lua
@@ -1156,6 +1156,7 @@ function ConsoleController:get_canvas()
 end
 
 --- @param f function
+--- @return any ... result of f
 function ConsoleController:use_canvas(f)
   local canvas = self.model.output.canvas
   gfx.setCanvas({

--- a/src/controller/consoleController.lua
+++ b/src/controller/consoleController.lua
@@ -1162,9 +1162,10 @@ function ConsoleController:use_canvas(f)
     canvas, -- this is actually [1] = canvas
     stencil = true
   })
-  local r = f()
+  local r = { pcall(f) }
   gfx.setCanvas()
-  return r
+  if not r[1] then error(r[2], 0) end
+  return unpack(r, 2)
 end
 
 --- @return ViewData


### PR DESCRIPTION
use_canvas bound the offscreen canvas, called f(), then restored with gfx.setCanvas(). If f() threw, the restore was skipped and all later rendering went to the offscreen canvas. Run f() under pcall, always restore the canvas, then re-raise on failure and return f()'s values on success. Error propagation and return values are preserved; only the cleanup is now guaranteed.