### PR TITLE
fix(lang): keep highlighter from propagating lexer errors (A1)

### DIFF
--- a/src/model/lang/lua/parser.lua
+++ b/src/model/lang/lua/parser.lua
@@ -296,7 +296,11 @@ return function(lib)
   --- @param code str
   --- @return SyntaxColoring
   local highlighter = function(code)
-    return syntax_hl(tokenize(code))
+    local ok, tokens = pcall(tokenize, code)
+    if not ok then
+      return SyntaxColoring()
+    end
+    return syntax_hl(tokens)
   end
 
   --- @param text string[]

--- a/tests/interpreter/parser_spec.lua
+++ b/tests/interpreter/parser_spec.lua
@@ -103,4 +103,11 @@ describe('highlight #parser', function()
       end
     end)
   end
+
+  it('does not propagate lexer errors', function()
+    local invalid = 'local s = "\\999"'
+    local ok, hl = pcall(parser.highlighter, invalid)
+    assert.is_true(ok)
+    assert.are_equal('table', type(hl))
+  end)
 end)


### PR DESCRIPTION
`parse` consumes the token stream inside `pcall`, but `highlighter` realizes the same stream unprotected, so a lexer-level error (e.g. a string escape above 255: "\999", lexer.lua:289) propagates out of syntax highlighting and crashes the app on text change.
Guard the token realization the same way `parse` does and fall back to an empty `SyntaxColoring` — consumers handle it by design (auto-vivifying table), and the error position still gets marked through the `parse` path.
Adds a regression test; the test fails without the fix.