### PR TITLE
fix: correct malformed type() checks (C7)

### DIFF
--- a/src/model/input/userInputModel.lua
+++ b/src/model/input/userInputModel.lua
@@ -867,7 +867,7 @@ end
 function UserInputModel:set_error(errors)
   self.error = nil
   if type(errors) == "table" then
-    if type(errors[1] == "string") then
+    if type(errors[1]) == "string" then
       self.error = errors
     else
       self.error = {}

--- a/src/model/lang/md/parser.lua
+++ b/src/model/lang/md/parser.lua
@@ -78,7 +78,7 @@ local function parse(input, skip_posinfo)
 end
 
 local function is_lua_block(t)
-  if not type(t) == "table" then return false end
+  if type(t) ~= "table" then return false end
   return t.t == 'code_block' and t.lang == 'lua'
 end
 

--- a/src/util/table.lua
+++ b/src/util/table.lua
@@ -198,7 +198,7 @@ end
 --- @param self table
 --- @return boolean is_array
 function table.is_array(self)
-  if not self or not type(self) == "table" then
+  if not self or type(self) ~= "table" then
     return false
   end
   local is_array = true
@@ -215,7 +215,7 @@ end
 --- @param depth integer?
 --- @return table?
 function table.flatten(self, depth)
-  if not self or not type(self) == "table" then
+  if not self or type(self) ~= "table" then
     return
   end
   local d = depth or 1
@@ -236,7 +236,7 @@ end
 --- @param self table
 --- @return table?
 function table.odds(self)
-  if not self or not type(self) == "table" then
+  if not self or type(self) ~= "table" then
     return
   end
   local ret = {}

--- a/tests/input/user_input_model_spec.lua
+++ b/tests/input/user_input_model_spec.lua
@@ -30,6 +30,16 @@ describe("input model spec #input", function()
   -----------------
   --   ASCII     --
   -----------------
+  describe('errors', function()
+    it('converts non-string errors', function()
+      local model = UserInputModel(mockConf, luaEval)
+      --- @diagnostic disable-next-line: invisible
+      model:set_error({ 42 })
+      --- @diagnostic disable-next-line: invisible
+      assert.same({ '42' }, model.error)
+    end)
+  end)
+
   describe('basics', function()
     local model = UserInputModel(mockConf, luaEval)
 

--- a/tests/util/table_spec.lua
+++ b/tests/util/table_spec.lua
@@ -13,6 +13,10 @@ describe('table utils #table', function()
       assert.is_false(table.is_array(t3))
       assert.is_false(table.is_array(t4))
     end)
+    it('rejects non-tables', function()
+      assert.is_false(table.is_array('str'))
+      assert.is_false(table.is_array(42))
+    end)
   end)
 
   describe('odds', function()
@@ -26,6 +30,10 @@ describe('table utils #table', function()
   end)
 
   describe('flatten', function()
+    it('rejects non-tables', function()
+      assert.is_nil(table.flatten(42))
+    end)
+
     it('one deep', function()
       assert.same({}, table.flatten({}))
 


### PR DESCRIPTION
Five type() guards across the codebase share one defect shape — the comparison ends up inside the type() call, or `not` binds to type() before the comparison — so the guard never does its job:
 1. `table.is_array`, `table.flatten`, `table.odds` (util/table.lua): `not type(self) == "table"` is always false, so the check reduces to `not self`, and passing any non-table scalar crashes on `pairs` instead of returning false/nil. These are reachable through `analyze.lua` and `debug.lua`.
 2 `UserInputModel:set_error`: `type(errors[1] == "string")` is `type(boolean)`, always truthy, so the branch that converts non-string errors with `tostring` is dead and raw error tables are stored in a field annotated `string[]`. The display path happens to `tostring` elements anyway, which masks it today, but any other consumer of the field gets tables where strings are promised.
 3. `is_lua_block` (md/parser.lua): `not type(t) == "table"` never returns early; strings survive by accident (string indexing doesn't raise), other scalars would.
 All five become the intended `type(x) ~= "table"` / `type(x) == "string"` forms.
 The same pattern exists once more in the stringutils submodule (string.lua:241) — out of scope here, can be fixed upstream separately.