### PR TITLE
perf(input): cut per-character render cost (D2)

### DIFF
--- a/src/util/view.lua
+++ b/src/util/view.lua
@@ -36,7 +36,7 @@ end
 --- @param selected boolean
 local write_token = function(dy, dx, token,
                              color, bgcolor, selected)
-  gfx.push('all')
+  local r, g, b, a = gfx.getColor()
   if selected then
     gfx.setColor(color)
     local back = string.rep('█', string.ulen(token))
@@ -46,7 +46,7 @@ local write_token = function(dy, dx, token,
     gfx.setColor(color)
   end
   gfx.print(token, dx, dy)
-  gfx.pop()
+  gfx.setColor(r, g, b, a)
 end
 
 --- Hide elements for debugging

--- a/src/view/input/userInputView.lua
+++ b/src/view/input/userInputView.lua
@@ -103,7 +103,6 @@ function UserInputView:render_input(input, status, time)
   local apparentHeight = inHeight
 
   local wrap_forward = vc.wrap_forward
-  local wrap_reverse = vc.wrap_reverse
 
 
   local vpH = gfx.getHeight()
@@ -166,7 +165,6 @@ function UserInputView:render_input(input, status, time)
         local char = string.usub(s, c, c)
         local color = colors.fg
 
-        local hl_li = wrap_reverse[ln]
         local tlc = vc:translate_from_visible(Cursor(l, c))
 
         if tlc then
@@ -204,11 +202,6 @@ function UserInputView:render_input(input, status, time)
             end
           end
         end)()
-        local of = calc_overflow(w, text, cursorInfo.cursor)
-        --- push any further lines down to display phantom line
-        if ofpos and hl_li > cl then
-          of = of - 1
-        end
         local dy = (l) * fh
         local dx = (c - 1) * fw
         ViewUtils.write_token(dy, dx,

--- a/tests/util/view_spec.lua
+++ b/tests/util/view_spec.lua
@@ -1,0 +1,45 @@
+local mock = require("tests.mock")
+mock.mock_love({})
+require("util.view")
+
+describe('view utils #view', function()
+  local prev_gfx
+  local color
+
+  setup(function()
+    prev_gfx = _G.gfx
+    color = { 1, 1, 1, 1 }
+    _G.gfx = {
+      getColor = function()
+        return color[1], color[2], color[3], color[4]
+      end,
+      setColor = function(r, g, b, a)
+        if type(r) == 'table' then
+          color = { r[1], r[2], r[3], r[4] }
+        else
+          color = { r, g, b, a }
+        end
+      end,
+      print = function() end,
+    }
+  end)
+
+  teardown(function()
+    _G.gfx = prev_gfx
+  end)
+
+  describe('write_token', function()
+    it('leaves the active color untouched', function()
+      gfx.setColor(0.1, 0.2, 0.3, 1)
+      ViewUtils.write_token(0, 0, 'x',
+        { 1, 0, 0, 1 }, { 0, 0, 0, 1 }, false)
+      local r, g, b = gfx.getColor()
+      assert.same({ 0.1, 0.2, 0.3 }, { r, g, b })
+
+      ViewUtils.write_token(0, 0, 'x',
+        { 1, 0, 0, 1 }, { 0, 0, 0, 1 }, true)
+      r, g, b = gfx.getColor()
+      assert.same({ 0.1, 0.2, 0.3 }, { r, g, b })
+    end)
+  end)
+end)


### PR DESCRIPTION
The input render loop pays two per-character costs on every frame:
 1.`write_token` wraps every character in `gfx.push('all')` / `gfx.pop()`, saving and restoring the entire graphics state (transform, scissor, shader, ...) although the function only ever mutates the color. On a fully highlighted 64x16 input that is up to ~1000 full-state save/restore pairs per frame. Replaced with saving and restoring just the color; the sequence of `setColor`/`print` calls is unchanged, so the output is identical by construction.
 2.the character loop computes `calc_overflow` (and a `wrap_reverse` lookup feeding it) for every character, then discards the result — `of` is written, conditionally decremented, and never read. `calc_overflow` is pure, and its one real call site at the top of `render_input` stays. The dead chain (`wrap_reverse` local, `hl_li`, the in-loop `calc_overflow` and its guard) is removed.
 Neither change can alter a pixel: the first preserves the exact draw-call sequence, the second deletes computation whose result was never consumed.

This deliberately does not touch redraw frequency (dirty-gating the input like the terminal in #26 would) — that part needs the same on-device validation as #26 and can follow once that protocol is settled. What's here is the half of the finding that is provable from the code alone. 