### PR TITLE
fix(input): balance the draw stack on early return (A2)

### DIFF
--- a/src/view/input/userInputView.lua
+++ b/src/view/input/userInputView.lua
@@ -160,7 +160,10 @@ function UserInputView:render_input(input, status, time)
     for l, s in ipairs(visible) do
       local ln = l + vc.offset
       local tl = string.ulen(s)
-      if not tl then return end
+      if not tl then
+        gfx.pop()
+        return
+      end
 
       for c = 1, tl do
         local char = string.usub(s, c, c)


### PR DESCRIPTION
The input render loop opens with `gfx.push('all')` and has an early return in the middle (`if not tl then return end`) that skips the closing `gfx.pop()`. Whenever that branch is taken, one graphics stack level leaks per frame until LÖVE's stack depth cap is hit. The trigger is content whose `string.ulen` is nil — see the companion PR for how such content gets in and for keeping it out at the model boundary; this change makes the draw scope exception-safe regardless of content, same shape as the use_canvas fix (#37).