### PR TITLE
fix(input): sanitize incoming text against invalid UTF-8 (A3)

### DIFF
--- a/src/model/input/userInputModel.lua
+++ b/src/model/input/userInputModel.lua
@@ -82,6 +82,19 @@ function UserInputModel:init_visible(text)
   self.visible:set_default_range()
 end
 
+--- Drop bytes that do not form valid UTF-8
+--- @param s string
+--- @return string
+local function sanitize_utf8(s)
+  local r = s
+  local n, pos = utf8.len(r)
+  while not n do
+    r = string.sub(r, 1, pos - 1) .. string.sub(r, pos + 1)
+    n, pos = utf8.len(r)
+  end
+  return r
+end
+
 ----------------
 --  entered   --
 ----------------
@@ -89,6 +102,7 @@ end
 --- @param text string
 function UserInputModel:add_text(text)
   if type(text) == 'string' then
+    text = sanitize_utf8(text)
     self:pop_selected_text()
     local sl, cc    = self:get_cursor_pos()
     local cur_line  = self:get_text_line(sl)
@@ -127,6 +141,7 @@ end
 --- @param keep_cursor boolean
 function UserInputModel:set_text(text, keep_cursor)
   if type(text) == 'string' then
+    text = sanitize_utf8(text)
     local lines = string.lines(text)
     local n_added = #lines
     if n_added == 1 then
@@ -136,7 +151,11 @@ function UserInputModel:set_text(text, keep_cursor)
       self:_update_cursor(true)
     end
   elseif type(text) == 'table' then
-    self.entered = InputText(text)
+    local clean = {}
+    for i, l in ipairs(text) do
+      clean[i] = sanitize_utf8(l)
+    end
+    self.entered = InputText(clean)
   end
   self:text_change()
   if not keep_cursor then

--- a/tests/input/user_input_model_spec.lua
+++ b/tests/input/user_input_model_spec.lua
@@ -40,6 +40,34 @@ describe("input model spec #input", function()
     end)
   end)
 
+  describe('invalid UTF-8', function()
+    local invalid = 'abc\195('
+
+    it('add_text drops invalid bytes', function()
+      local model = UserInputModel(mockConf, luaEval)
+      model:add_text(invalid)
+      assert.same({ 'abc(' }, model:get_text())
+    end)
+
+    it('paste drops invalid bytes across lines', function()
+      local model = UserInputModel(mockConf, luaEval)
+      model:paste('abc\ndef' .. invalid)
+      assert.same({ 'abc', 'defabc(' }, model:get_text())
+    end)
+
+    it('set_text drops invalid bytes', function()
+      local model = UserInputModel(mockConf, luaEval)
+      model:set_text(invalid)
+      assert.same({ 'abc(' }, model:get_text())
+    end)
+
+    it('set_text drops invalid bytes in tables', function()
+      local model = UserInputModel(mockConf, luaEval)
+      model:set_text({ 'ok', invalid })
+      assert.same({ 'ok', 'abc(' }, model:get_text())
+    end)
+  end)
+
   describe('basics', function()
     local model = UserInputModel(mockConf, luaEval)
 


### PR DESCRIPTION
Invalid UTF-8 reaching the input model makes `string.ulen` return nil, and the model does unguarded arithmetic on that in several places: a multi-line paste crashes at userInputModel.lua:120, `set_text` with a string at :475, and with a table at :730 (`ulen(...) + 1` in each case). A single-line paste doesn't crash — it silently plants the invalid bytes into `entered`, which is what makes the render loop bail out early every frame (see the companion draw-stack PR).
The fix sanitizes text at the model's entry points (`add_text`, both branches of `set_text`): bytes that don't form valid UTF-8 are dropped, using `utf8.len`'s error position to cut them out. Invalid bytes can arrive through the clipboard (`paste` in userInputController) or through the project-facing input API. Sanitizing at the boundary keeps the invariant "entered never holds invalid bytes", which covers every `ulen` arithmetic site in the model at once — there are more of them than the three that crash today.
One call worth surfacing: invalid bytes are dropped, not replaced with U+FFFD. A visible replacement character would land inside source code and produce a compile error that's hard to explain to a child, and rejecting the whole paste over one bad byte felt harsher than losing it. If visible markers are preferred, it's a one-line change in the sanitizer.
Companion to the draw-stack fix: with the boundary invariant in place, the view's nil-ulen branch becomes unreachable in practice; the other PR makes it safe even if reached.