### PR TITLE
fix(editor): expose filesystem info for checkpoints

### DIFF
--- a/src/util/filesystem.lua
+++ b/src/util/filesystem.lua
@@ -1,5 +1,10 @@
 local OS = require("util.os") --- pulls in string
 
+---@class FileInfo
+---@field type love.FileType
+---@field size number?
+---@field modtime number?
+
 local FS = {
   path_sep = (function()
     if love and love.system
@@ -122,13 +127,21 @@ if love and not TESTING then
   --- @param path string
   --- @param filtertype love.FileType?
   --- @param vfs boolean?
+  --- @return FileInfo?
+  function FS.getInfo(path, filtertype, vfs)
+    if vfs then
+      return LFS.getInfo(path, filtertype)
+    else
+      return _fs.getInfo(path, filtertype)
+    end
+  end
+
+  --- @param path string
+  --- @param filtertype love.FileType?
+  --- @param vfs boolean?
   --- @return boolean
   function FS.exists(path, filtertype, vfs)
-    if vfs then
-      return LFS.getInfo(path, filtertype) and true or false
-    else
-      return _fs.getInfo(path, filtertype) and true or false
-    end
+    return FS.getInfo(path, filtertype, vfs) and true or false
   end
 
   --- @param path string
@@ -407,14 +420,32 @@ else
   end
 
   --- @param path string
+  --- @param filtertype love.FileType?
+  --- @return FileInfo?
+  function FS.getInfo(path, filtertype)
+    local attrs = lfs.attributes(path)
+    if not attrs then return end
+
+    --- @type table<string, love.FileType>
+    local types = {
+      file = 'file',
+      directory = 'directory',
+    }
+    local filetype = types[attrs.mode] or 'other'
+    if filtertype and filtertype ~= filetype then return end
+
+    return {
+      type = filetype,
+      size = attrs.size,
+      modtime = attrs.modification,
+    }
+  end
+
+  --- @param path string
+  --- @param filtertype love.FileType?
   --- @return boolean exists
-  function FS.exists(path)
-    local f = io.open(path, 'r')
-    if f then
-      io.close(f)
-      return true
-    end
-    return false
+  function FS.exists(path, filtertype)
+    return FS.getInfo(path, filtertype) and true or false
   end
 
   --- @param path string

--- a/tests/util/fs_spec.lua
+++ b/tests/util/fs_spec.lua
@@ -52,4 +52,24 @@ describe("FS utils", function()
       assert.are.equal('a/b/c', FS.join_path('a', 'b', 'c'))
     end)
   end)
+
+  describe('gets file information', function()
+    local path
+
+    after_each(function()
+      if path then os.remove(path) end
+    end)
+
+    it('returns metadata and applies the type filter', function()
+      path = os.tmpname()
+      local ok = FS.write(path, 'x = 1\n')
+      assert.is_true(ok)
+
+      local info = assert(FS.getInfo(path, 'file'))
+      assert.same('file', info.type)
+      assert.same(6, info.size)
+      assert.is_number(info.modtime)
+      assert.is_nil(FS.getInfo(path, 'directory'))
+    end)
+  end)
 end)


### PR DESCRIPTION
## What

- expose `FS.getInfo(path, filtertype, vfs)` through the runtime filesystem adapter
- define the returned `FileInfo` shape for LuaCATS-aware editor tooling
- mirror the same metadata API in the test backend using `lfs.attributes`
- route `FS.exists` through `FS.getInfo`
- cover metadata shape and type filtering in the filesystem specs

## Why

The checkpoint timestamp lookup calls `FS.getInfo`, but the adapter only exposed `FS.exists`. The missing method crashes the first checkpoint attempt. This isolates the adapter fix as one commit on top of `aldum/dev`.

## API compatibility

The production `FS.exists` signature was already `(path, filtertype, vfs)`. This change adds the optional `filtertype` argument only to the test backend, bringing it in line with production. Omitting the argument still passes `nil` and checks for any filesystem entry, so existing one-argument calls keep the same behavior. Existing production callers use the filter to distinguish files from directories.

`FileInfo.type` is a `love.FileType`; `size` and `modtime` are optional because LÖVE may be unable to determine them. The test backend uses `lfs.attributes`, which follows symbolic links, so it maps only LuaFileSystem's `file` and `directory` modes directly and reports other modes as LÖVE's `other`. It does not claim `symlink` semantics.

## Validation

- `tests/util/fs_spec.lua`: 9 successes, 0 failures, 0 errors
- full Lua 5.1 suite: 687 successes, 0 failures, 0 errors
- `luac5.1 -p src/util/filesystem.lua tests/util/fs_spec.lua`
- `git diff --check origin/dev...HEAD`
